### PR TITLE
Fixes path issue when we are using absolute path

### DIFF
--- a/src/Sitecore.Ship.Infrastructure/Web/ServerTempFile.cs
+++ b/src/Sitecore.Ship.Infrastructure/Web/ServerTempFile.cs
@@ -10,7 +10,7 @@ namespace Sitecore.Ship.Infrastructure.Web
         {
             get
             {
-                return HttpContext.Current.Server.MapPath(Sitecore.IO.TempFolder.GetFilename(Guid.NewGuid() + ".update"));
+                return Sitecore.IO.FileUtil.MapPath(Sitecore.IO.TempFolder.GetFilename(Guid.NewGuid() + ".update"));
             }
         }
     }


### PR DESCRIPTION
I encountered an issue, described [here](https://sitecore.stackexchange.com/questions/3373/updateinstallationwizard-aspx-and-or-sitecore-ship-isnt-working) while running on Azure web apps. Luckily, I found solution for this problem [here](https://sitecore.stackexchange.com/a/6846/181)

IMHO, it is valuable addition to Sitecore.ShipIt, as it will allow to run it flawlessly on Azure Web apps, where, by default, we are using absolute path for temp folder