### PR TITLE
If no languages specified in request - we shall publish all languages

### DIFF
--- a/src/Sitecore.Ship.AspNet/Publish/InvokePublishingCommand.cs
+++ b/src/Sitecore.Ship.AspNet/Publish/InvokePublishingCommand.cs
@@ -98,7 +98,7 @@ namespace Sitecore.Ship.AspNet.Publish
 					Mode = request.Url.PathAndQuery.Split(new[] {'/'}).Last(),
 					Source = request.Form["source"] ?? "master",
 					Targets = request.Form["targets"].CsvStringToStringArray(new[] { "web" }),
-					Languages = request.Form["languages"].CsvStringToStringArray(new[] { "en" })
+					Languages = request.Form["languages"].CsvStringToStringArray(null)
 				};
 
 			return publishRequest;

--- a/src/Sitecore.Ship.Infrastructure/PublishService.cs
+++ b/src/Sitecore.Ship.Infrastructure/PublishService.cs
@@ -12,96 +12,96 @@ using Sitecore.Ship.Core.Domain;
 
 namespace Sitecore.Ship.Infrastructure
 {
-    public class PublishService : IPublishService
-    {
-        private readonly Dictionary<string, Func<Database, Database[], Language[], Handle>> _publishingActions;
+	public class PublishService : IPublishService
+	{
+		private readonly Dictionary<string, Func<Database, Database[], Language[], Handle>> _publishingActions;
 
-        public PublishService()
-        {
-            _publishingActions = new Dictionary<string, Func<Database, Database[], Language[], Handle>>
-                {
-                    { "full",           Publishing.PublishManager.Republish },
-                    { "smart",          Publishing.PublishManager.PublishSmart },
-                    { "incremental",    Publishing.PublishManager.PublishIncremental }
-                };
-        }
+		public PublishService()
+		{
+			_publishingActions = new Dictionary<string, Func<Database, Database[], Language[], Handle>>
+				{
+					{ "full",           Publishing.PublishManager.Republish },
+					{ "smart",          Publishing.PublishManager.PublishSmart },
+					{ "incremental",    Publishing.PublishManager.PublishIncremental }
+				};
+		}
 
-        public void Run(ItemsToPublish itemsToPublish)
-        {
-            if (itemsToPublish == null)
-            {
-                throw new ArgumentNullException("itemsToPublish");
-            }
+		public void Run(ItemsToPublish itemsToPublish)
+		{
+			if (itemsToPublish == null)
+			{
+				throw new ArgumentNullException("itemsToPublish");
+			}
 
-            if (itemsToPublish.Items.Count == 0)
-            {
-                return;
-            }
+			if (itemsToPublish.Items.Count == 0)
+			{
+				return;
+			}
 
-            using (new SecurityModel.SecurityDisabler())
-            {
-                var master = Sitecore.Configuration.Factory.GetDatabase("master");
-                var languages = itemsToPublish.TargetLanguages.Select(LanguageManager.GetLanguage).ToArray();
+			using (new SecurityModel.SecurityDisabler())
+			{
+				var master = Sitecore.Configuration.Factory.GetDatabase("master");
+				var languages = itemsToPublish.TargetLanguages.Select(LanguageManager.GetLanguage).ToArray();
 
-                foreach (var itemToPublish in itemsToPublish.Items)
-                {
-                    var item = master.GetItem(new ID(itemToPublish));
-                    if (item != null)
-                    {
-                        Publishing.PublishManager.PublishItem(item, itemsToPublish.TargetDatabases.Select(Sitecore.Configuration.Factory.GetDatabase).ToArray(), languages, true, true);
-                    }
-                }
-            }
-        }
+				foreach (var itemToPublish in itemsToPublish.Items)
+				{
+					var item = master.GetItem(new ID(itemToPublish));
+					if (item != null)
+					{
+						Publishing.PublishManager.PublishItem(item, itemsToPublish.TargetDatabases.Select(Sitecore.Configuration.Factory.GetDatabase).ToArray(), languages, true, true);
+					}
+				}
+			}
+		}
 
-        public void Run(PublishParameters publishParameters)
-        {
-            var publishingMode = publishParameters.Mode.ToLower();
+		public void Run(PublishParameters publishParameters)
+		{
+			var publishingMode = publishParameters.Mode.ToLower();
 
-            if (!_publishingActions.ContainsKey(publishingMode))
-            {
-                throw new InvalidOperationException(string.Format("Invalid publishing mode ({0})", publishingMode));
-            }
+			if (!_publishingActions.ContainsKey(publishingMode))
+			{
+				throw new InvalidOperationException(string.Format("Invalid publishing mode ({0})", publishingMode));
+			}
 
-            PublishingTask(_publishingActions[publishingMode], publishParameters);
-        }
+			PublishingTask(_publishingActions[publishingMode], publishParameters);
+		}
 
-        public DateTime GetLastCompletedRun(PublishLastCompleted completeParameters)
-        {
-            // please note http://stackoverflow.com/questions/12416141/get-the-date-time-that-sitecore-last-published
+		public DateTime GetLastCompletedRun(PublishLastCompleted completeParameters)
+		{
+			// please note http://stackoverflow.com/questions/12416141/get-the-date-time-that-sitecore-last-published
 
-            var source = Sitecore.Configuration.Factory.GetDatabase(completeParameters.Source);
-            var target = Sitecore.Configuration.Factory.GetDatabase(completeParameters.Target);
+			var source = Sitecore.Configuration.Factory.GetDatabase(completeParameters.Source);
+			var target = Sitecore.Configuration.Factory.GetDatabase(completeParameters.Target);
+			
+			var language = LanguageManager.GetLanguage(completeParameters.Language);
 
-            var language = LanguageManager.GetLanguage(completeParameters.Language);
 
+			Assert.IsNotNull(source, "Source database {0} cannot be found".Formatted(completeParameters.Source));
+			Assert.IsNotNull(source, "Target database {0} cannot be found".Formatted(completeParameters.Target));
+			Assert.IsNotNull(language, "Language {0} cannot be found".Formatted(completeParameters.Language));
 
-            Assert.IsNotNull(source, "Source database {0} cannot be found".Formatted(completeParameters.Source));
-            Assert.IsNotNull(source, "Target database {0} cannot be found".Formatted(completeParameters.Target));
-            Assert.IsNotNull(language, "Language {0} cannot be found".Formatted(completeParameters.Language));
+			var date = source.Properties.GetLastPublishDate(target, language);
+			return date;
+		}
 
-            var date = source.Properties.GetLastPublishDate(target, language);
-            return date;
-        }
+		private static void PublishingTask(Func<Database, Database[], Language[], Handle> publishType, PublishParameters publishParameters)
+		{
+			using (new SecurityModel.SecurityDisabler())
+			{
+				var master = Sitecore.Configuration.Factory.GetDatabase(publishParameters.Source);
+				var targetDBs = publishParameters.Targets.Select(Sitecore.Configuration.Factory.GetDatabase).ToArray();
+				Language[] languages;
+				if (publishParameters.Languages == null)
+				{
+					languages = LanguageManager.GetLanguages(master).ToArray();
+				}
+				else
+				{
+					languages = publishParameters.Languages.Select(LanguageManager.GetLanguage).ToArray();
+				}
 
-        private static void PublishingTask(Func<Database, Database[], Language[], Handle> publishType, PublishParameters publishParameters)
-        {
-            using (new SecurityModel.SecurityDisabler())
-            {
-                var master = Sitecore.Configuration.Factory.GetDatabase(publishParameters.Source);
-                var targetDBs = publishParameters.Targets.Select(Sitecore.Configuration.Factory.GetDatabase).ToArray();
-                Language[] languages;
-                if (publishParameters.Languages == null)
-                {
-                    languages = LanguageManager.GetLanguages(master).ToArray();
-                }
-                else
-                {
-                    languages = publishParameters.Languages.Select(LanguageManager.GetLanguage).ToArray();
-                }
-                
-                publishType(master, targetDBs, languages);
-            }
-        }
-    }
+				publishType(master, targetDBs, languages);
+			}
+		}
+	}
 }

--- a/src/Sitecore.Ship.Infrastructure/PublishService.cs
+++ b/src/Sitecore.Ship.Infrastructure/PublishService.cs
@@ -12,88 +12,96 @@ using Sitecore.Ship.Core.Domain;
 
 namespace Sitecore.Ship.Infrastructure
 {
-	public class PublishService : IPublishService
-	{
-		private readonly Dictionary<string, Func<Database, Database[], Language[], Handle>> _publishingActions;
+    public class PublishService : IPublishService
+    {
+        private readonly Dictionary<string, Func<Database, Database[], Language[], Handle>> _publishingActions;
 
-		public PublishService()
-		{
-			_publishingActions = new Dictionary<string, Func<Database, Database[], Language[], Handle>>
-				{
-					{ "full",           Publishing.PublishManager.Republish },
-					{ "smart",          Publishing.PublishManager.PublishSmart },
-					{ "incremental",    Publishing.PublishManager.PublishIncremental }
-				};
-		}
+        public PublishService()
+        {
+            _publishingActions = new Dictionary<string, Func<Database, Database[], Language[], Handle>>
+                {
+                    { "full",           Publishing.PublishManager.Republish },
+                    { "smart",          Publishing.PublishManager.PublishSmart },
+                    { "incremental",    Publishing.PublishManager.PublishIncremental }
+                };
+        }
 
-		public void Run(ItemsToPublish itemsToPublish)
-		{
-			if (itemsToPublish == null)
-			{
-				throw new ArgumentNullException("itemsToPublish");
-			}
+        public void Run(ItemsToPublish itemsToPublish)
+        {
+            if (itemsToPublish == null)
+            {
+                throw new ArgumentNullException("itemsToPublish");
+            }
 
-			if (itemsToPublish.Items.Count == 0)
-			{
-				return;
-			}
+            if (itemsToPublish.Items.Count == 0)
+            {
+                return;
+            }
 
-			using (new SecurityModel.SecurityDisabler())
-			{
-				var master = Sitecore.Configuration.Factory.GetDatabase("master");
-				var languages = itemsToPublish.TargetLanguages.Select(LanguageManager.GetLanguage).ToArray();
+            using (new SecurityModel.SecurityDisabler())
+            {
+                var master = Sitecore.Configuration.Factory.GetDatabase("master");
+                var languages = itemsToPublish.TargetLanguages.Select(LanguageManager.GetLanguage).ToArray();
 
-				foreach (var itemToPublish in itemsToPublish.Items)
-				{
-					var item = master.GetItem(new ID(itemToPublish));
-					if (item != null)
-					{
-						Publishing.PublishManager.PublishItem(item, itemsToPublish.TargetDatabases.Select(Sitecore.Configuration.Factory.GetDatabase).ToArray(), languages, true, true);
-					}
-				}
-			}
-		}
+                foreach (var itemToPublish in itemsToPublish.Items)
+                {
+                    var item = master.GetItem(new ID(itemToPublish));
+                    if (item != null)
+                    {
+                        Publishing.PublishManager.PublishItem(item, itemsToPublish.TargetDatabases.Select(Sitecore.Configuration.Factory.GetDatabase).ToArray(), languages, true, true);
+                    }
+                }
+            }
+        }
 
-		public void Run(PublishParameters publishParameters)
-		{
-			var publishingMode = publishParameters.Mode.ToLower();
+        public void Run(PublishParameters publishParameters)
+        {
+            var publishingMode = publishParameters.Mode.ToLower();
 
-			if (!_publishingActions.ContainsKey(publishingMode))
-			{
-				throw new InvalidOperationException(string.Format("Invalid publishing mode ({0})", publishingMode));
-			}
+            if (!_publishingActions.ContainsKey(publishingMode))
+            {
+                throw new InvalidOperationException(string.Format("Invalid publishing mode ({0})", publishingMode));
+            }
 
-			PublishingTask(_publishingActions[publishingMode], publishParameters);
-		}
+            PublishingTask(_publishingActions[publishingMode], publishParameters);
+        }
 
-		public DateTime GetLastCompletedRun(PublishLastCompleted completeParameters)
-		{
-			// please note http://stackoverflow.com/questions/12416141/get-the-date-time-that-sitecore-last-published
+        public DateTime GetLastCompletedRun(PublishLastCompleted completeParameters)
+        {
+            // please note http://stackoverflow.com/questions/12416141/get-the-date-time-that-sitecore-last-published
 
-			var source = Sitecore.Configuration.Factory.GetDatabase(completeParameters.Source);
-			var target = Sitecore.Configuration.Factory.GetDatabase(completeParameters.Target);
-			
-			var language = LanguageManager.GetLanguage(completeParameters.Language);
+            var source = Sitecore.Configuration.Factory.GetDatabase(completeParameters.Source);
+            var target = Sitecore.Configuration.Factory.GetDatabase(completeParameters.Target);
+
+            var language = LanguageManager.GetLanguage(completeParameters.Language);
 
 
-			Assert.IsNotNull(source, "Source database {0} cannot be found".Formatted(completeParameters.Source));
-			Assert.IsNotNull(source, "Target database {0} cannot be found".Formatted(completeParameters.Target));
-			Assert.IsNotNull(language, "Language {0} cannot be found".Formatted(completeParameters.Language));
+            Assert.IsNotNull(source, "Source database {0} cannot be found".Formatted(completeParameters.Source));
+            Assert.IsNotNull(source, "Target database {0} cannot be found".Formatted(completeParameters.Target));
+            Assert.IsNotNull(language, "Language {0} cannot be found".Formatted(completeParameters.Language));
 
-			var date = source.Properties.GetLastPublishDate(target, language);
-			return date;
-		}
+            var date = source.Properties.GetLastPublishDate(target, language);
+            return date;
+        }
 
-		private static void PublishingTask(Func<Database, Database[], Language[], Handle> publishType, PublishParameters publishParameters)
-		{
-			using (new SecurityModel.SecurityDisabler())
-			{
-				var master = Sitecore.Configuration.Factory.GetDatabase(publishParameters.Source);
-				var targetDBs = publishParameters.Targets.Select(Sitecore.Configuration.Factory.GetDatabase).ToArray();
-				var languages = publishParameters.Languages.Select(LanguageManager.GetLanguage).ToArray();
-
-				publishType(master, targetDBs, languages);
-			}
-		}
-	}
+        private static void PublishingTask(Func<Database, Database[], Language[], Handle> publishType, PublishParameters publishParameters)
+        {
+            using (new SecurityModel.SecurityDisabler())
+            {
+                var master = Sitecore.Configuration.Factory.GetDatabase(publishParameters.Source);
+                var targetDBs = publishParameters.Targets.Select(Sitecore.Configuration.Factory.GetDatabase).ToArray();
+                Language[] languages;
+                if (publishParameters.Languages == null)
+                {
+                    languages = LanguageManager.GetLanguages(master).ToArray();
+                }
+                else
+                {
+                    languages = publishParameters.Languages.Select(LanguageManager.GetLanguage).ToArray();
+                }
+                
+                publishType(master, targetDBs, languages);
+            }
+        }
+    }
 }

--- a/src/Sitecore.Ship/Publish/PublishModule.cs
+++ b/src/Sitecore.Ship/Publish/PublishModule.cs
@@ -57,7 +57,7 @@ namespace Sitecore.Ship.Publish
                     Mode = publishRequest.Mode,
                     Source = publishRequest.Source ?? "master",
                     Targets = publishRequest.Targets.CsvStringToStringArray(new[] {"web"}),
-                    Languages = publishRequest.Languages.CsvStringToStringArray(new[] {"en"}),
+                    Languages = publishRequest.Languages.CsvStringToStringArray(null),
                 };
 
             var now = DateTime.Now;


### PR DESCRIPTION
First of all, I wish to question the decision to use "en" language, if no languages is specified - it could easily be, that default language is not EN (there is a setting for this, called DefaultLanguage).
Also, when you have 10-15 languages in your solution and this amount could grow fast - defining additional languages could be real pain. So, with this PR I propose to allow to publish all languages, if target language is not defined